### PR TITLE
Stress Testing CLI Command

### DIFF
--- a/src/oasees_sdk/cli/cli.py
+++ b/src/oasees_sdk/cli/cli.py
@@ -274,19 +274,21 @@ def init(expose_ip,update,iface):
     else:
         click.secho("Please install Helm and / or Kompose before trying again.", fg="red")
 
+def uninstall_util(role):
+    if(role=='master'):
+        result = subprocess.run(['/usr/local/bin/k3s-uninstall.sh'],  stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        click.echo("Cluster uninstalled successfully.")
+    elif (role=='agent'):
+        result = subprocess.run(['/usr/local/bin/k3s-agent-uninstall.sh'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        click.echo("Agent uninstalled successfully.")
+    else:
+        click.echo("Enter a valid role (master / agent)")
 @cli.command()
 @click.argument('role', type=str)
 def uninstall(role):
     '''Runs the appropriate k3s uninstallation script based on the role provided.'''
     try:
-        if(role=='master'):
-            result = subprocess.run(['/usr/local/bin/k3s-uninstall.sh'],  stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
-            click.echo("Cluster uninstalled successfully.")
-        elif (role=='agent'):
-            result = subprocess.run(['/usr/local/bin/k3s-agent-uninstall.sh'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
-            click.echo("Agent uninstalled successfully.")
-        else:
-            click.echo("Enter a valid role (master / agent)")
+        uninstall_util(role)
     except FileNotFoundError:
         click.echo("Error: Uninstall executable not found.")
 

--- a/src/oasees_sdk/cli/cli.py
+++ b/src/oasees_sdk/cli/cli.py
@@ -301,13 +301,7 @@ def get_token():
     except FileNotFoundError:
         click.echo("Error: No token found.")
 
-
-@cli.command()
-@click.option('--ip', required=True, help="The cluster's master ip address.")
-@click.option('--token', required=True, help="The cluster's master token.")
-@click.option('--iface', required=False, help="The network interface you want to join with (tun0 if you're using a VPN connection).")
-def join(ip,token,iface):
-    '''Joins the current machine to the specified cluster, using the specified interface if one is provided.'''
+def join_util(ip, token, iface):
     try:
         curl = subprocess.Popen(['curl','-sfL', 'https://get.k3s.io'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
 
@@ -319,6 +313,14 @@ def join(ip,token,iface):
         curl.wait()
     except FileNotFoundError:
         click.echo("Error: K3S cluster could not be joined.\n")
+
+@cli.command()
+@click.option('--ip', required=True, help="The cluster's master ip address.")
+@click.option('--token', required=True, help="The cluster's master token.")
+@click.option('--iface', required=False, help="The network interface you want to join with (tun0 if you're using a VPN connection).")
+def join(ip,token,iface):
+    '''Joins the current machine to the specified cluster, using the specified interface if one is provided.'''
+    return join_util(ip, token, iface)
 
 
 @cli.command()


### PR DESCRIPTION
Refactored CLI commands to allow their core logic to be called as functions directly within Python. This change simplifies writing automated and integration tests, as demonstrated by the new stress test code developed in the ```OASEES-Perf-Sim``` repository.